### PR TITLE
Handle OSError exception

### DIFF
--- a/sftp-exporter.py
+++ b/sftp-exporter.py
@@ -280,12 +280,13 @@ def check(callback, **sftp_details):
                         for folder in folders
                     ]
                 )
-        except asyncssh.Error:
-            logger.exception('Failed to establish connection to {}'.format(host))
-            sftp_host_up.labels(host, username, 'ConnectError').set(now)
         except socket.gaierror:
             logger.exception('Not found host name {}'.format(host))
             sftp_host_up.labels(host, username, 'DNSError').set(now)
+        except (OSError, asyncssh.Error):
+            logger.exception(
+                'Failed to establish connection to {}'.format(host))
+            sftp_host_up.labels(host, username, 'ConnectError').set(now)
         finally:
             if conn:
                 conn.close()

--- a/sftp-exporter.py
+++ b/sftp-exporter.py
@@ -284,8 +284,7 @@ def check(callback, **sftp_details):
             logger.exception('Not found host name {}'.format(host))
             sftp_host_up.labels(host, username, 'DNSError').set(now)
         except (OSError, asyncssh.Error):
-            logger.exception(
-                'Failed to establish connection to {}'.format(host))
+            logger.exception('Failed to establish connection to {}'.format(host))
             sftp_host_up.labels(host, username, 'ConnectError').set(now)
         finally:
             if conn:


### PR DESCRIPTION
This PR handles the following scenario:

- A machine with the service sftp disabled.
- sftp-exporter outputs the following:


```
INFO:__main__:Started loop for host example.com
INFO:asyncssh:Opening SSH connection to example.com, port 22
======== Running on http://127.0.0.1:9339 ========
(Press CTRL+C to quit)
ERROR:asyncio:Task exception was never retrieved
future: <Task finished name='Task-3' coro=<check.<locals>.checker() done, defined at /Users/santi/apps/sftp-exporter/sftp-exporter.py:252> exception=ConnectionRefusedError(61, "Connect call failed ('35.200.32.101', 22)")>
Traceback (most recent call last):
  File "/Users/santi/apps/sftp-exporter/sftp-exporter.py", line 268, in checker
    conn = await asyncssh.connect(**kw)
  File "/Users/santi/Library/Python/3.9/lib/python/site-packages/asyncssh/connection.py", line 6685, in connect
    return await _connect(options, loop, flags, conn_factory,
  File "/Users/santi/Library/Python/3.9/lib/python/site-packages/asyncssh/connection.py", line 222, in _connect
    _, conn = await loop.create_connection(conn_factory, host, port,
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 1065, in create_connection
    raise exceptions[0]
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 1050, in create_connection
    sock = await self._connect_sock(
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 961, in _connect_sock
    await self.sock_connect(sock, address)
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/selector_events.py", line 500, in sock_connect
    return await fut
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/selector_events.py", line 535, in _sock_connect_cb
    raise OSError(err, f'Connect call failed {address}')
ConnectionRefusedError: [Errno 61] Connect call failed ('35.200.32.101', 22)
```

And no metric is exported.

With this PR, we will see the following metric, as expected:

```
sftp_host_up{host="example.com",state="ConnectError",username="username"} 1.664314775e+09
```